### PR TITLE
Fix ok still here

### DIFF
--- a/src/imap4.c
+++ b/src/imap4.c
@@ -378,7 +378,7 @@ void imap_cb_time(void *arg)
 
 		ci_cork(session->ci);
 		if (! (++session->loop % idle_interval)) {
-			imap_session_printf(session, "* OK\r\n");
+			imap_session_printf(session, "* OK Still here\r\n");
 		}
 		dbmail_imap_session_mailbox_status(session,TRUE);
 		dbmail_imap_session_buff_flush(session);


### PR DESCRIPTION
Original implementation sent "* OK" as idle message, some client have hard time understanding the short message. Changed to "* OK Still here"